### PR TITLE
Only require something GLES 3 compatible from wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-activity"
+version = "0.1.1"
+source = "git+https://github.com/rib/android-activity#4818de6709fb4035e213a9474c30d8fc1e8360b7"
+dependencies = [
+ "android-properties",
+ "bitflags",
+ "cc",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk 0.7.0",
+ "ndk-context",
+ "ndk-sys 0.4.0",
+ "num_enum",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1194,7 @@ checksum = "6907e25393cdcc1f4f3f513d9aac1e840eb1cc341a0fccb01171f7d14d10b946"
 name = "eframe"
 version = "0.18.0"
 dependencies = [
+ "android-activity",
  "bytemuck",
  "dark-light",
  "directories-next",

--- a/eframe/Cargo.toml
+++ b/eframe/Cargo.toml
@@ -82,13 +82,18 @@ wgpu = { version = "0.13", optional = true }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dark-light = { version = "0.2.1", optional = true }
-egui-winit = { version = "0.18.0", path = "../egui-winit", default-features = false, features = ["clipboard", "links"] }
+egui-winit = { version = "0.18.0", path = "../egui-winit", default-features = false, features = ["links"] }
 glutin = { version = "0.29.0" }
 winit = "0.27.2"
 
 # optional native:
 puffin = { version = "0.13", optional = true }
 directories-next = { version = "2", optional = true }
+
+# -------------------------------------------
+# android
+[target.'cfg(target_os = "android")'.dependencies]
+android-activity = { git = "https://github.com/rib/android-activity", features = [ "game-activity" ] }
 
 # -------------------------------------------
 # web:

--- a/eframe/src/epi.rs
+++ b/eframe/src/epi.rs
@@ -6,6 +6,9 @@
 
 #![warn(missing_docs)] // Let's keep `epi` well-documented.
 
+#[cfg(target_os = "android")]
+use android_activity::AndroidApp;
+
 /// This is how your app is created.
 ///
 /// You can use the [`CreationContext`] to setup egui, restore state, setup OpenGL things, etc.
@@ -288,6 +291,9 @@ pub struct NativeOptions {
     /// When `true`, [`winit::platform::run_return::EventLoopExtRunReturn::run_return`] is used.
     /// When `false`, [`winit::event_loop::EventLoop::run`] is used.
     pub run_and_return: bool,
+
+    #[cfg(target_os = "android")]
+    pub android_app: Option<AndroidApp>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -315,6 +321,9 @@ impl Default for NativeOptions {
             follow_system_theme: cfg!(target_os = "macos") || cfg!(target_os = "windows"),
             default_theme: Theme::Dark,
             run_and_return: true,
+
+            #[cfg(target_os = "android")]
+            android_app: None,
         }
     }
 }

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -700,7 +700,7 @@ mod wgpu_integration {
                     wgpu::DeviceDescriptor {
                         label: None,
                         features: wgpu::Features::default(),
-                        limits: wgpu::Limits::default(),
+                        limits: wgpu::Limits::downlevel_webgl2_defaults(),
                     },
                     wgpu::PresentMode::Fifo,
                     self.native_options.multisampling.max(1) as _,

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use std::time::Instant;
 
 use egui_winit::winit;
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event_loop::{
+    ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy, EventLoopWindowTarget,
+};
 
 #[cfg(target_os = "android")]
 use winit::platform::android::EventLoopBuilderExtAndroid;
@@ -15,45 +17,6 @@ use crate::epi;
 
 #[derive(Debug)]
 struct RequestRepaintEvent;
-
-#[cfg(feature = "glow")]
-#[allow(unsafe_code)]
-fn create_display(
-    native_options: &NativeOptions,
-    window_builder: winit::window::WindowBuilder,
-    event_loop: &EventLoop<RequestRepaintEvent>,
-) -> (
-    glutin::WindowedContext<glutin::PossiblyCurrent>,
-    glow::Context,
-) {
-    crate::profile_function!();
-
-    use crate::HardwareAcceleration;
-
-    let hardware_acceleration = match native_options.hardware_acceleration {
-        HardwareAcceleration::Required => Some(true),
-        HardwareAcceleration::Preferred => None,
-        HardwareAcceleration::Off => Some(false),
-    };
-
-    let gl_window = unsafe {
-        glutin::ContextBuilder::new()
-            .with_hardware_acceleration(hardware_acceleration)
-            .with_depth_buffer(native_options.depth_buffer)
-            .with_multisampling(native_options.multisampling)
-            .with_srgb(true)
-            .with_stencil_buffer(native_options.stencil_buffer)
-            .with_vsync(native_options.vsync)
-            .build_windowed(window_builder, event_loop)
-            .unwrap()
-            .make_current()
-            .unwrap()
-    };
-
-    let gl = unsafe { glow::Context::from_loader_function(|s| gl_window.get_proc_address(s)) };
-
-    (gl_window, gl)
-}
 
 // ----------------------------------------------------------------------------
 
@@ -68,23 +31,59 @@ enum EventResult {
 
 trait WinitApp {
     fn is_focused(&self) -> bool;
-    fn integration(&self) -> &EpiIntegration;
-    fn window(&self) -> &winit::window::Window;
+    fn integration(&self) -> Option<&EpiIntegration>;
+    fn window(&self) -> Option<&winit::window::Window>;
     fn save_and_destroy(&mut self);
     fn paint(&mut self) -> EventResult;
-    fn on_event(&mut self, event: winit::event::Event<'_, RequestRepaintEvent>) -> EventResult;
+    fn on_event(
+        &mut self,
+        event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+        event: winit::event::Event<'_, RequestRepaintEvent>,
+    ) -> EventResult;
+}
+
+#[allow(unused)]
+fn create_event_loop_builder(
+    native_options: &epi::NativeOptions,
+) -> EventLoopBuilder<RequestRepaintEvent> {
+    let mut event_loop_builder = winit::event_loop::EventLoopBuilder::with_user_event();
+
+    #[cfg(target_os = "android")]
+    {
+        event_loop_builder.with_android_app(
+            native_options
+                .android_app
+                .clone()
+                .expect("No AndroidApp provided"),
+        );
+    }
+
+    event_loop_builder
 }
 
 /// Access a thread-local event loop.
 ///
 /// We reuse the event-loop so we can support closing and opening an eframe window
 /// multiple times. This is just a limitation of winit.
-fn with_event_loop(f: impl FnOnce(&mut EventLoop<RequestRepaintEvent>)) {
+fn with_event_loop(
+    native_options: &epi::NativeOptions,
+    f: impl FnOnce(&mut EventLoop<RequestRepaintEvent>),
+) {
     use std::cell::RefCell;
-    thread_local!(static EVENT_LOOP: RefCell<EventLoop<RequestRepaintEvent>> = RefCell::new(winit::event_loop::EventLoopBuilder::with_user_event().build()));
+    thread_local!(static EVENT_LOOP: RefCell<Option<EventLoop<RequestRepaintEvent>>> = RefCell::new(None));
 
     EVENT_LOOP.with(|event_loop| {
-        f(&mut *event_loop.borrow_mut());
+        // Since we want to reference NativeOptions when creating the EventLoop we can't
+        // do that as part of the lazy thread local storage initialization and so we instead
+        // create the event loop lazily here
+
+        let mut event_loop = event_loop.borrow_mut();
+        if event_loop.is_none() {
+            event_loop.replace(create_event_loop_builder(&native_options.clone()).build());
+        }
+        if let Some(event_loop) = event_loop.as_mut() {
+            f(event_loop);
+        }
     });
 }
 
@@ -95,7 +94,7 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
 
     let mut next_repaint_time = Instant::now();
 
-    event_loop.run_return(|event, _, control_flow| {
+    event_loop.run_return(|event, event_loop, control_flow| {
         let event_result = match event {
             winit::event::Event::LoopDestroyed => EventResult::Exit,
 
@@ -117,14 +116,15 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
             }) => EventResult::RepaintAsap,
 
             winit::event::Event::WindowEvent { window_id, .. }
-                if window_id != winit_app.window().id() =>
+                if winit_app.window().is_none()
+                    || window_id != winit_app.window().unwrap().id() =>
             {
                 // This can happen if we close a window, and then reopen a new one,
                 // or if we have multiple windows open.
                 EventResult::Wait
             }
 
-            event => winit_app.on_event(event),
+            event => winit_app.on_event(event_loop, event),
         };
 
         match event_result {
@@ -143,7 +143,9 @@ fn run_and_return(event_loop: &mut EventLoop<RequestRepaintEvent>, mut winit_app
 
         *control_flow = match next_repaint_time.checked_duration_since(Instant::now()) {
             None => {
-                winit_app.window().request_redraw();
+                if let Some(window) = winit_app.window() {
+                    window.request_redraw();
+                }
                 ControlFlow::Poll
             }
             Some(time_until_next_repaint) => {
@@ -172,7 +174,7 @@ fn run_and_exit(
 
     let mut next_repaint_time = Instant::now();
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, event_loop, control_flow| {
         let event_result = match event {
             winit::event::Event::LoopDestroyed => EventResult::Exit,
 
@@ -193,7 +195,7 @@ fn run_and_exit(
                 ..
             }) => EventResult::RepaintAsap,
 
-            event => winit_app.on_event(event),
+            event => winit_app.on_event(event_loop, event),
         };
 
         match event_result {
@@ -214,7 +216,9 @@ fn run_and_exit(
 
         *control_flow = match next_repaint_time.checked_duration_since(Instant::now()) {
             None => {
-                winit_app.window().request_redraw();
+                if let Some(window) = winit_app.window() {
+                    window.request_redraw();
+                }
                 ControlFlow::Poll
             }
             Some(time_until_next_repaint) => {
@@ -225,7 +229,6 @@ fn run_and_exit(
 }
 
 // ----------------------------------------------------------------------------
-
 /// Run an egui app
 #[cfg(feature = "glow")]
 mod glow_integration {
@@ -233,12 +236,43 @@ mod glow_integration {
 
     use super::*;
 
-    struct GlowWinitApp {
-        gl_window: glutin::WindowedContext<glutin::PossiblyCurrent>,
+    // Note: that the current Glutin API design tightly couples the GL context with
+    // the Window which means it's not practically possible to just destroy the
+    // window and re-create a new window while continuing to use the same GL context.
+    //
+    // For now this means it's not possible to support Android as well as we can with
+    // wgpu because we're basically forced to destroy and recreate _everything_ when
+    // the application suspends and resumes.
+    //
+    // There is work in progress to improve the Glutin API so it has a separate Surface
+    // API that would allow us to just destroy a Window/Surface when suspending, see:
+    // https://github.com/rust-windowing/glutin/pull/1435
+    //
+
+    /// State that is initialized when the application is first starts running via
+    /// a Resumed event. On Android this ensures that any graphics state is only
+    /// initialized once the application has an associated SurfaceView.
+    struct GlowWinitRunning {
         gl: Arc<glow::Context>,
         painter: egui_glow::Painter,
         integration: epi_integration::EpiIntegration,
         app: Box<dyn epi::App>,
+
+        // Conceptually this will be split out eventually so that the rest of the state
+        // can be persistent.
+        gl_window: glutin::WindowedContext<glutin::PossiblyCurrent>,
+    }
+
+    struct GlowWinitApp {
+        repaint_proxy: Arc<egui::mutex::Mutex<EventLoopProxy<RequestRepaintEvent>>>,
+        app_name: String,
+        native_options: epi::NativeOptions,
+        running: Option<GlowWinitRunning>,
+
+        // Note that since this `AppCreator` is FnOnce we are currently unable to support
+        // re-initializing the `GlowWinitRunning` state on Android if the application
+        // suspends and resumes.
+        app_creator: Option<epi::AppCreator>,
         is_focused: bool,
     }
 
@@ -249,18 +283,75 @@ mod glow_integration {
             native_options: &epi::NativeOptions,
             app_creator: epi::AppCreator,
         ) -> Self {
-            let storage = epi_integration::create_storage(app_name);
+            Self {
+                repaint_proxy: Arc::new(egui::mutex::Mutex::new(event_loop.create_proxy())),
+                app_name: app_name.to_string(),
+                native_options: native_options.clone(),
+                running: None,
+                app_creator: Some(app_creator),
+                is_focused: true,
+            }
+        }
+
+        #[allow(unsafe_code)]
+        fn create_glutin_windowed_context(
+            event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+            storage: Option<&dyn epi::Storage>,
+            title: &String,
+            native_options: &NativeOptions,
+        ) -> (
+            glutin::WindowedContext<glutin::PossiblyCurrent>,
+            glow::Context,
+        ) {
+            crate::profile_function!();
+
+            use crate::HardwareAcceleration;
+
+            let hardware_acceleration = match native_options.hardware_acceleration {
+                HardwareAcceleration::Required => Some(true),
+                HardwareAcceleration::Preferred => None,
+                HardwareAcceleration::Off => Some(false),
+            };
             let window_settings = epi_integration::load_window_settings(storage.as_deref());
 
-            let window_builder = epi_integration::window_builder(native_options, &window_settings)
-                .with_title(app_name);
-            let (gl_window, gl) = create_display(native_options, window_builder, event_loop);
+            let window_builder =
+                epi_integration::window_builder(native_options, &window_settings).with_title(title);
+
+            let gl_window = unsafe {
+                glutin::ContextBuilder::new()
+                    .with_hardware_acceleration(hardware_acceleration)
+                    .with_depth_buffer(native_options.depth_buffer)
+                    .with_multisampling(native_options.multisampling)
+                    .with_srgb(true)
+                    .with_stencil_buffer(native_options.stencil_buffer)
+                    .with_vsync(native_options.vsync)
+                    .build_windowed(window_builder, event_loop)
+                    .unwrap()
+                    .make_current()
+                    .unwrap()
+            };
+
+            let gl =
+                unsafe { glow::Context::from_loader_function(|s| gl_window.get_proc_address(s)) };
+
+            (gl_window, gl)
+        }
+
+        fn init_run_state(&mut self, event_loop: &EventLoopWindowTarget<RequestRepaintEvent>) {
+            let storage = epi_integration::create_storage(&self.app_name);
+
+            let (gl_window, gl) = Self::create_glutin_windowed_context(
+                event_loop,
+                storage.as_deref(),
+                &self.app_name,
+                &self.native_options,
+            );
             let gl = Arc::new(gl);
 
             let painter = egui_glow::Painter::new(gl.clone(), None, "")
                 .unwrap_or_else(|error| panic!("some OpenGL error occurred {}\n", error));
 
-            let system_theme = native_options.system_theme();
+            let system_theme = self.native_options.system_theme();
             let mut integration = epi_integration::EpiIntegration::new(
                 event_loop,
                 painter.max_texture_side(),
@@ -271,16 +362,18 @@ mod glow_integration {
                 #[cfg(feature = "wgpu")]
                 None,
             );
-            let theme = system_theme.unwrap_or(native_options.default_theme);
+            let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
             {
-                let event_loop_proxy = egui::mutex::Mutex::new(event_loop.create_proxy());
+                let event_loop_proxy = self.repaint_proxy.clone();
                 integration.egui_ctx.set_request_repaint_callback(move || {
                     event_loop_proxy.lock().send_event(RequestRepaintEvent).ok();
                 });
             }
 
+            let app_creator = std::mem::take(&mut self.app_creator)
+                .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
                 egui_ctx: integration.egui_ctx.clone(),
                 integration_info: integration.frame.info(),
@@ -294,14 +387,13 @@ mod glow_integration {
                 integration.warm_up(app.as_mut(), gl_window.window());
             }
 
-            Self {
+            self.running = Some(GlowWinitRunning {
                 gl_window,
                 gl,
                 painter,
                 integration,
                 app,
-                is_focused: true,
-            }
+            });
         }
     }
 
@@ -310,139 +402,180 @@ mod glow_integration {
             self.is_focused
         }
 
-        fn integration(&self) -> &EpiIntegration {
-            &self.integration
+        fn integration(&self) -> Option<&EpiIntegration> {
+            self.running.as_ref().map(|r| &r.integration)
         }
 
-        fn window(&self) -> &winit::window::Window {
-            self.gl_window.window()
+        fn window(&self) -> Option<&winit::window::Window> {
+            self.running.as_ref().map(|r| r.gl_window.window())
         }
 
         fn save_and_destroy(&mut self) {
-            self.integration
-                .save(&mut *self.app, self.gl_window.window());
-            self.app.on_exit(Some(&self.gl));
-            self.painter.destroy();
+            if let Some(running) = &mut self.running {
+                running
+                    .integration
+                    .save(running.app.as_mut(), running.gl_window.window());
+                running.app.on_exit(Some(&running.gl));
+                running.painter.destroy();
+            }
         }
 
         fn paint(&mut self) -> EventResult {
-            #[cfg(feature = "puffin")]
-            puffin::GlobalProfiler::lock().new_frame();
-            crate::profile_scope!("frame");
+            if let Some(running) = &mut self.running {
+                #[cfg(feature = "puffin")]
+                puffin::GlobalProfiler::lock().new_frame();
+                crate::profile_scope!("frame");
 
-            let Self {
-                gl_window,
-                gl,
-                app,
-                integration,
-                painter,
-                ..
-            } = self;
-            let window = gl_window.window();
+                let GlowWinitRunning {
+                    gl_window,
+                    gl,
+                    app,
+                    integration,
+                    painter,
+                    ..
+                } = running;
 
-            let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
+                let window = gl_window.window();
 
-            egui_glow::painter::clear(
-                gl,
-                screen_size_in_pixels,
-                app.clear_color(&integration.egui_ctx.style().visuals),
-            );
+                let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
-            let egui::FullOutput {
-                platform_output,
-                repaint_after,
-                textures_delta,
-                shapes,
-            } = integration.update(app.as_mut(), window);
+                egui_glow::painter::clear(
+                    gl,
+                    screen_size_in_pixels,
+                    app.clear_color(&integration.egui_ctx.style().visuals),
+                );
 
-            integration.handle_platform_output(window, platform_output);
+                let egui::FullOutput {
+                    platform_output,
+                    repaint_after,
+                    textures_delta,
+                    shapes,
+                } = integration.update(app.as_mut(), window);
 
-            let clipped_primitives = {
-                crate::profile_scope!("tessellate");
-                integration.egui_ctx.tessellate(shapes)
-            };
+                integration.handle_platform_output(window, platform_output);
 
-            painter.paint_and_update_textures(
-                screen_size_in_pixels,
-                integration.egui_ctx.pixels_per_point(),
-                &clipped_primitives,
-                &textures_delta,
-            );
+                let clipped_primitives = {
+                    crate::profile_scope!("tessellate");
+                    integration.egui_ctx.tessellate(shapes)
+                };
 
-            integration.post_rendering(app.as_mut(), window);
+                painter.paint_and_update_textures(
+                    screen_size_in_pixels,
+                    integration.egui_ctx.pixels_per_point(),
+                    &clipped_primitives,
+                    &textures_delta,
+                );
 
-            {
-                crate::profile_scope!("swap_buffers");
-                gl_window.swap_buffers().unwrap();
-            }
+                integration.post_rendering(app.as_mut(), window);
 
-            let control_flow = if integration.should_quit() {
-                EventResult::Exit
-            } else if repaint_after.is_zero() {
-                EventResult::RepaintAsap
-            } else if let Some(repaint_after_instant) =
-                std::time::Instant::now().checked_add(repaint_after)
-            {
-                // if repaint_after is something huge and can't be added to Instant,
-                // we will use `ControlFlow::Wait` instead.
-                // technically, this might lead to some weird corner cases where the user *WANTS*
-                // winit to use `WaitUntil(MAX_INSTANT)` explicitly. they can roll their own
-                // egui backend impl i guess.
-                EventResult::RepaintAt(repaint_after_instant)
+                {
+                    crate::profile_scope!("swap_buffers");
+                    gl_window.swap_buffers().unwrap();
+                }
+
+                let control_flow = if integration.should_quit() {
+                    EventResult::Exit
+                } else if repaint_after.is_zero() {
+                    EventResult::RepaintAsap
+                } else if let Some(repaint_after_instant) =
+                    std::time::Instant::now().checked_add(repaint_after)
+                {
+                    // if repaint_after is something huge and can't be added to Instant,
+                    // we will use `ControlFlow::Wait` instead.
+                    // technically, this might lead to some weird corner cases where the user *WANTS*
+                    // winit to use `WaitUntil(MAX_INSTANT)` explicitly. they can roll their own
+                    // egui backend impl i guess.
+                    EventResult::RepaintAt(repaint_after_instant)
+                } else {
+                    EventResult::Wait
+                };
+
+                integration.maybe_autosave(app.as_mut(), window);
+
+                if !self.is_focused {
+                    // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
+                    // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
+                    // But we know if we are focused (in foreground). When minimized, we are not focused.
+                    // However, a user may want an egui with an animation in the background,
+                    // so we still need to repaint quite fast.
+                    crate::profile_scope!("bg_sleep");
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+
+                control_flow
             } else {
                 EventResult::Wait
-            };
-
-            integration.maybe_autosave(app.as_mut(), window);
-
-            if !self.is_focused {
-                // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
-                // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
-                // But we know if we are focused (in foreground). When minimized, we are not focused.
-                // However, a user may want an egui with an animation in the background,
-                // so we still need to repaint quite fast.
-                crate::profile_scope!("bg_sleep");
-                std::thread::sleep(std::time::Duration::from_millis(10));
             }
-
-            control_flow
         }
 
-        fn on_event(&mut self, event: winit::event::Event<'_, RequestRepaintEvent>) -> EventResult {
+        fn on_event(
+            &mut self,
+            event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+            event: winit::event::Event<'_, RequestRepaintEvent>,
+        ) -> EventResult {
             match event {
-                winit::event::Event::WindowEvent { event, .. } => {
-                    match &event {
-                        winit::event::WindowEvent::Focused(new_focused) => {
-                            self.is_focused = *new_focused;
-                        }
-                        winit::event::WindowEvent::Resized(physical_size) => {
-                            // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
-                            // See: https://github.com/rust-windowing/winit/issues/208
-                            // This solves an issue where the app would panic when minimizing on Windows.
-                            if physical_size.width > 0 && physical_size.height > 0 {
-                                self.gl_window.resize(*physical_size);
-                            }
-                        }
-                        winit::event::WindowEvent::ScaleFactorChanged {
-                            new_inner_size, ..
-                        } => {
-                            self.gl_window.resize(**new_inner_size);
-                        }
-                        winit::event::WindowEvent::CloseRequested
-                            if self.integration.should_quit() =>
-                        {
-                            return EventResult::Exit
-                        }
-                        _ => {}
+                winit::event::Event::Resumed => {
+                    if self.running.is_none() {
+                        self.init_run_state(event_loop);
                     }
+                    EventResult::RepaintAsap
+                }
+                winit::event::Event::Suspended => {
+                    #[cfg(target = "android")]
+                    {
+                        tracing::error!("Suspended app can't destroy Window surface state with current Egui Glow backend (undefined behaviour)");
+                        // Instead of destroying everything which we _know_ we can't re-create
+                        // we instead currently just try our luck with not destroying anything.
+                        //
+                        // When the application resumes then it will get a new SurfaceView but
+                        // we have no practical way currently of creating a new EGL surface
+                        // via the Glutin API while keeping the GL context and the rest of
+                        // our app state. This will likely result in a black screen or
+                        // frozen screen.
+                        //
+                        //self.running = None;
+                    }
+                    EventResult::Wait
+                }
 
-                    self.integration.on_event(self.app.as_mut(), &event);
+                winit::event::Event::WindowEvent { event, .. } => {
+                    if let Some(running) = &mut self.running {
+                        match &event {
+                            winit::event::WindowEvent::Focused(new_focused) => {
+                                self.is_focused = *new_focused;
+                            }
+                            winit::event::WindowEvent::Resized(physical_size) => {
+                                // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
+                                // See: https://github.com/rust-windowing/winit/issues/208
+                                // This solves an issue where the app would panic when minimizing on Windows.
+                                if physical_size.width > 0 && physical_size.height > 0 {
+                                    running.gl_window.resize(*physical_size);
+                                }
+                            }
+                            winit::event::WindowEvent::ScaleFactorChanged {
+                                new_inner_size,
+                                ..
+                            } => {
+                                running.gl_window.resize(**new_inner_size);
+                            }
+                            winit::event::WindowEvent::CloseRequested
+                                if running.integration.should_quit() =>
+                            {
+                                return EventResult::Exit
+                            }
+                            _ => {}
+                        }
 
-                    if self.integration.should_quit() {
-                        EventResult::Exit
+                        running.integration.on_event(running.app.as_mut(), &event);
+
+                        if running.integration.should_quit() {
+                            EventResult::Exit
+                        } else {
+                            // TODO(emilk): ask egui if the event warrants a repaint
+                            EventResult::RepaintAsap
+                        }
                     } else {
-                        // TODO(emilk): ask egui if the event warrants a repaint
-                        EventResult::RepaintAsap
+                        EventResult::Wait
                     }
                 }
                 _ => EventResult::Wait,
@@ -456,13 +589,13 @@ mod glow_integration {
         app_creator: epi::AppCreator,
     ) {
         if native_options.run_and_return {
-            with_event_loop(|event_loop| {
+            with_event_loop(native_options, |event_loop| {
                 let glow_eframe =
                     GlowWinitApp::new(event_loop, app_name, native_options, app_creator);
                 run_and_return(event_loop, glow_eframe);
             });
         } else {
-            let event_loop = winit::event_loop::EventLoopBuilder::with_user_event().build();
+            let event_loop = create_event_loop_builder(native_options).build();
             let glow_eframe = GlowWinitApp::new(&event_loop, app_name, native_options, app_creator);
             run_and_exit(event_loop, glow_eframe);
         }
@@ -471,18 +604,33 @@ mod glow_integration {
 
 #[cfg(feature = "glow")]
 pub use glow_integration::run_glow;
-
 // ----------------------------------------------------------------------------
 
 #[cfg(feature = "wgpu")]
 mod wgpu_integration {
+    use std::sync::Arc;
+
     use super::*;
 
-    struct WgpuWinitApp {
-        window: winit::window::Window,
+    /// State that is initialized when the application is first starts running via
+    /// a Resumed event. On Android this ensures that any graphics state is only
+    /// initialized once the application has an associated SurfaceView.
+    struct WgpuWinitRunning {
         painter: egui_wgpu::winit::Painter<'static>,
         integration: epi_integration::EpiIntegration,
         app: Box<dyn epi::App>,
+    }
+
+    struct WgpuWinitApp {
+        repaint_proxy: Arc<std::sync::Mutex<EventLoopProxy<RequestRepaintEvent>>>,
+        app_name: String,
+        native_options: epi::NativeOptions,
+        app_creator: Option<epi::AppCreator>,
+        running: Option<WgpuWinitRunning>,
+
+        /// Window surface state that's initialized when the app starts running via a Resumed event
+        /// and on Android will also be destroyed if the application is paused.
+        window: Option<winit::window::Window>,
         is_focused: bool,
     }
 
@@ -493,15 +641,57 @@ mod wgpu_integration {
             native_options: &epi::NativeOptions,
             app_creator: epi::AppCreator,
         ) -> Self {
-            let storage = epi_integration::create_storage(app_name);
-            let window_settings = epi_integration::load_window_settings(storage.as_deref());
+            Self {
+                repaint_proxy: Arc::new(std::sync::Mutex::new(event_loop.create_proxy())),
+                app_name: app_name.to_string(),
+                native_options: native_options.clone(),
+                running: None,
+                window: None,
+                app_creator: Some(app_creator),
+                is_focused: true,
+            }
+        }
 
+        fn create_window(
+            event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+            storage: Option<&dyn epi::Storage>,
+            title: &String,
+            native_options: &NativeOptions,
+        ) -> winit::window::Window {
+            let window_settings = epi_integration::load_window_settings(storage);
             let window = epi_integration::window_builder(native_options, &window_settings)
-                .with_title(app_name)
+                .with_title(title)
                 .build(event_loop)
                 .unwrap();
 
-            // SAFETY: `window` must outlive `painter`.
+            window
+        }
+
+        fn set_window(&mut self, window: winit::window::Window) {
+            self.window = Some(window);
+            if let Some(running) = &mut self.running {
+                unsafe {
+                    running.painter.set_window(self.window.as_ref());
+                }
+            }
+        }
+
+        #[cfg(target = "android")]
+        fn drop_window(&mut self) {
+            self.window = None;
+            if let Some(running) = &mut self.running {
+                unsafe {
+                    self.painter.set_window(None);
+                }
+            }
+        }
+
+        fn init_run_state(
+            &mut self,
+            event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+            storage: Option<Box<dyn epi::Storage>>,
+            window: winit::window::Window,
+        ) {
             #[allow(unsafe_code, unused_mut, unused_unsafe)]
             let painter = unsafe {
                 let mut painter = egui_wgpu::winit::Painter::new(
@@ -513,16 +703,15 @@ mod wgpu_integration {
                         limits: wgpu::Limits::default(),
                     },
                     wgpu::PresentMode::Fifo,
-                    native_options.multisampling.max(1) as _,
+                    self.native_options.multisampling.max(1) as _,
                 );
-                #[cfg(not(target_os = "android"))]
                 painter.set_window(Some(&window));
                 painter
             };
 
             let wgpu_render_state = painter.render_state();
 
-            let system_theme = native_options.system_theme();
+            let system_theme = self.native_options.system_theme();
             let mut integration = epi_integration::EpiIntegration::new(
                 event_loop,
                 painter.max_texture_side().unwrap_or(2048),
@@ -533,16 +722,22 @@ mod wgpu_integration {
                 None,
                 wgpu_render_state.clone(),
             );
-            let theme = system_theme.unwrap_or(native_options.default_theme);
+            let theme = system_theme.unwrap_or(self.native_options.default_theme);
             integration.egui_ctx.set_visuals(theme.egui_visuals());
 
             {
-                let event_loop_proxy = egui::mutex::Mutex::new(event_loop.create_proxy());
+                let event_loop_proxy = self.repaint_proxy.clone();
                 integration.egui_ctx.set_request_repaint_callback(move || {
-                    event_loop_proxy.lock().send_event(RequestRepaintEvent).ok();
+                    event_loop_proxy
+                        .lock()
+                        .unwrap()
+                        .send_event(RequestRepaintEvent)
+                        .ok();
                 });
             }
 
+            let app_creator = std::mem::take(&mut self.app_creator)
+                .expect("Single-use AppCreator has unexpectedly already been taken");
             let mut app = app_creator(&epi::CreationContext {
                 egui_ctx: integration.egui_ctx.clone(),
                 integration_info: integration.frame.info(),
@@ -556,13 +751,12 @@ mod wgpu_integration {
                 integration.warm_up(app.as_mut(), &window);
             }
 
-            Self {
-                window,
+            self.running = Some(WgpuWinitRunning {
                 painter,
                 integration,
                 app,
-                is_focused: true,
-            }
+            });
+            self.window = Some(window);
         }
     }
 
@@ -571,141 +765,178 @@ mod wgpu_integration {
             self.is_focused
         }
 
-        fn integration(&self) -> &EpiIntegration {
-            &self.integration
+        fn integration(&self) -> Option<&EpiIntegration> {
+            self.running.as_ref().map(|r| &r.integration)
         }
 
-        fn window(&self) -> &winit::window::Window {
-            &self.window
+        fn window(&self) -> Option<&winit::window::Window> {
+            self.window.as_ref()
         }
 
         fn save_and_destroy(&mut self) {
-            self.integration.save(&mut *self.app, &self.window);
+            if let Some(running) = &mut self.running {
+                if let Some(window) = &self.window {
+                    running.integration.save(running.app.as_mut(), window);
+                }
 
-            #[cfg(feature = "glow")]
-            self.app.on_exit(None);
+                #[cfg(feature = "glow")]
+                running.app.on_exit(None);
 
-            #[cfg(not(feature = "glow"))]
-            self.app.on_exit();
+                #[cfg(not(feature = "glow"))]
+                running.app.on_exit();
 
-            self.painter.destroy();
+                running.painter.destroy();
+            }
         }
 
         fn paint(&mut self) -> EventResult {
-            #[cfg(feature = "puffin")]
-            puffin::GlobalProfiler::lock().new_frame();
-            crate::profile_scope!("frame");
+            if let (Some(running), Some(window)) = (&mut self.running, &self.window) {
+                #[cfg(feature = "puffin")]
+                puffin::GlobalProfiler::lock().new_frame();
+                crate::profile_scope!("frame");
 
-            let Self {
-                window,
-                app,
-                integration,
-                painter,
-                ..
-            } = self;
+                let WgpuWinitRunning {
+                    app,
+                    integration,
+                    painter,
+                    ..
+                } = running;
 
-            let egui::FullOutput {
-                platform_output,
-                repaint_after,
-                textures_delta,
-                shapes,
-            } = integration.update(app.as_mut(), window);
+                let egui::FullOutput {
+                    platform_output,
+                    repaint_after,
+                    textures_delta,
+                    shapes,
+                } = integration.update(app.as_mut(), window);
 
-            integration.handle_platform_output(window, platform_output);
+                integration.handle_platform_output(window, platform_output);
 
-            let clipped_primitives = {
-                crate::profile_scope!("tessellate");
-                integration.egui_ctx.tessellate(shapes)
-            };
+                let clipped_primitives = {
+                    crate::profile_scope!("tessellate");
+                    integration.egui_ctx.tessellate(shapes)
+                };
 
-            painter.paint_and_update_textures(
-                integration.egui_ctx.pixels_per_point(),
-                app.clear_color(&integration.egui_ctx.style().visuals),
-                &clipped_primitives,
-                &textures_delta,
-            );
+                painter.paint_and_update_textures(
+                    integration.egui_ctx.pixels_per_point(),
+                    app.clear_color(&integration.egui_ctx.style().visuals),
+                    &clipped_primitives,
+                    &textures_delta,
+                );
 
-            integration.post_rendering(app.as_mut(), window);
+                integration.post_rendering(app.as_mut(), window);
 
-            let control_flow = if integration.should_quit() {
-                EventResult::Exit
-            } else if repaint_after.is_zero() {
-                EventResult::RepaintAsap
-            } else if let Some(repaint_after_instant) =
-                std::time::Instant::now().checked_add(repaint_after)
-            {
-                // if repaint_after is something huge and can't be added to Instant,
-                // we will use `ControlFlow::Wait` instead.
-                // technically, this might lead to some weird corner cases where the user *WANTS*
-                // winit to use `WaitUntil(MAX_INSTANT)` explicitly. they can roll their own
-                // egui backend impl i guess.
-                EventResult::RepaintAt(repaint_after_instant)
+                let control_flow = if integration.should_quit() {
+                    EventResult::Exit
+                } else if repaint_after.is_zero() {
+                    EventResult::RepaintAsap
+                } else if let Some(repaint_after_instant) =
+                    std::time::Instant::now().checked_add(repaint_after)
+                {
+                    // if repaint_after is something huge and can't be added to Instant,
+                    // we will use `ControlFlow::Wait` instead.
+                    // technically, this might lead to some weird corner cases where the user *WANTS*
+                    // winit to use `WaitUntil(MAX_INSTANT)` explicitly. they can roll their own
+                    // egui backend impl i guess.
+                    EventResult::RepaintAt(repaint_after_instant)
+                } else {
+                    EventResult::Wait
+                };
+
+                integration.maybe_autosave(app.as_mut(), window);
+
+                if !self.is_focused {
+                    // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
+                    // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
+                    // But we know if we are focused (in foreground). When minimized, we are not focused.
+                    // However, a user may want an egui with an animation in the background,
+                    // so we still need to repaint quite fast.
+                    crate::profile_scope!("bg_sleep");
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+
+                control_flow
             } else {
                 EventResult::Wait
-            };
-
-            integration.maybe_autosave(app.as_mut(), window);
-
-            if !self.is_focused {
-                // On Mac, a minimized Window uses up all CPU: https://github.com/emilk/egui/issues/325
-                // We can't know if we are minimized: https://github.com/rust-windowing/winit/issues/208
-                // But we know if we are focused (in foreground). When minimized, we are not focused.
-                // However, a user may want an egui with an animation in the background,
-                // so we still need to repaint quite fast.
-                crate::profile_scope!("bg_sleep");
-                std::thread::sleep(std::time::Duration::from_millis(10));
             }
-
-            control_flow
         }
 
-        fn on_event(&mut self, event: winit::event::Event<'_, RequestRepaintEvent>) -> EventResult {
+        fn on_event(
+            &mut self,
+            event_loop: &EventLoopWindowTarget<RequestRepaintEvent>,
+            event: winit::event::Event<'_, RequestRepaintEvent>,
+        ) -> EventResult {
             match event {
-                #[cfg(target_os = "android")]
-                winit::event::Event::Resumed => unsafe {
-                    self.painter.set_window(Some(&self.window));
+                winit::event::Event::Resumed => {
+                    if let Some(running) = &self.running {
+                        if self.window.is_none() {
+                            let window = Self::create_window(
+                                event_loop,
+                                running.integration.frame.storage(),
+                                &self.app_name,
+                                &self.native_options,
+                            );
+                            self.set_window(window);
+                        }
+                    } else {
+                        let storage = epi_integration::create_storage(&self.app_name);
+                        let window = Self::create_window(
+                            event_loop,
+                            storage.as_deref(),
+                            &self.app_name,
+                            &self.native_options,
+                        );
+                        self.init_run_state(event_loop, storage, window);
+                    }
                     EventResult::RepaintAsap
-                },
-                #[cfg(target_os = "android")]
-                winit::event::Event::Suspended => unsafe {
-                    self.painter.set_window(None);
+                }
+                winit::event::Event::Suspended => {
+                    #[cfg(target = "android")]
+                    self.drop_window();
                     EventResult::Wait
-                },
+                }
 
                 winit::event::Event::WindowEvent { event, .. } => {
-                    match &event {
-                        winit::event::WindowEvent::Focused(new_focused) => {
-                            self.is_focused = *new_focused;
-                        }
-                        winit::event::WindowEvent::Resized(physical_size) => {
-                            // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
-                            // See: https://github.com/rust-windowing/winit/issues/208
-                            // This solves an issue where the app would panic when minimizing on Windows.
-                            if physical_size.width > 0 && physical_size.height > 0 {
-                                self.painter
-                                    .on_window_resized(physical_size.width, physical_size.height);
+                    if let Some(running) = &mut self.running {
+                        match &event {
+                            winit::event::WindowEvent::Focused(new_focused) => {
+                                self.is_focused = *new_focused;
                             }
-                        }
-                        winit::event::WindowEvent::ScaleFactorChanged {
-                            new_inner_size, ..
-                        } => {
-                            self.painter
-                                .on_window_resized(new_inner_size.width, new_inner_size.height);
-                        }
-                        winit::event::WindowEvent::CloseRequested
-                            if self.integration.should_quit() =>
-                        {
-                            return EventResult::Exit
-                        }
-                        _ => {}
-                    };
+                            winit::event::WindowEvent::Resized(physical_size) => {
+                                // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
+                                // See: https://github.com/rust-windowing/winit/issues/208
+                                // This solves an issue where the app would panic when minimizing on Windows.
+                                if physical_size.width > 0 && physical_size.height > 0 {
+                                    running.painter.on_window_resized(
+                                        physical_size.width,
+                                        physical_size.height,
+                                    );
+                                }
+                            }
+                            winit::event::WindowEvent::ScaleFactorChanged {
+                                new_inner_size,
+                                ..
+                            } => {
+                                running
+                                    .painter
+                                    .on_window_resized(new_inner_size.width, new_inner_size.height);
+                            }
+                            winit::event::WindowEvent::CloseRequested
+                                if running.integration.should_quit() =>
+                            {
+                                return EventResult::Exit
+                            }
+                            _ => {}
+                        };
 
-                    self.integration.on_event(self.app.as_mut(), &event);
-                    if self.integration.should_quit() {
-                        EventResult::Exit
+                        running.integration.on_event(running.app.as_mut(), &event);
+                        if running.integration.should_quit() {
+                            EventResult::Exit
+                        } else {
+                            // TODO(emilk): ask egui if the event warrants a repaint
+                            EventResult::RepaintAsap
+                        }
                     } else {
-                        // TODO(emilk): ask egui if the event warrants a repaint
-                        EventResult::RepaintAsap
+                        EventResult::Wait
                     }
                 }
                 _ => EventResult::Wait,
@@ -719,25 +950,13 @@ mod wgpu_integration {
         app_creator: epi::AppCreator,
     ) {
         if native_options.run_and_return {
-            with_event_loop(|event_loop| {
+            with_event_loop(native_options, |event_loop| {
                 let wgpu_eframe =
                     WgpuWinitApp::new(event_loop, app_name, native_options, app_creator);
                 run_and_return(event_loop, wgpu_eframe);
             });
         } else {
-            let mut event_loop_builder = winit::event_loop::EventLoopBuilder::with_user_event();
-
-            #[cfg(target_os = "android")]
-            {
-                event_loop_builder.with_android_app(
-                    native_options
-                        .android_app
-                        .clone()
-                        .expect("No AndroidApp provided"),
-                );
-            }
-
-            let event_loop = event_loop_builder.build();
+            let event_loop = create_event_loop_builder(native_options).build();
             let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
             run_and_exit(event_loop, wgpu_eframe);
         }

--- a/eframe/src/native/run.rs
+++ b/eframe/src/native/run.rs
@@ -7,6 +7,9 @@ use std::time::Instant;
 use egui_winit::winit;
 use winit::event_loop::{ControlFlow, EventLoop};
 
+#[cfg(target_os = "android")]
+use winit::platform::android::EventLoopBuilderExtAndroid;
+
 use super::epi_integration::{self, EpiIntegration};
 use crate::epi;
 
@@ -202,7 +205,7 @@ fn run_and_exit(
                 next_repaint_time = next_repaint_time.min(repaint_time);
             }
             EventResult::Exit => {
-                tracing::debug!("Quitting…");
+                tracing::debug!("Quitting�");
                 winit_app.save_and_destroy();
                 #[allow(clippy::exit)]
                 std::process::exit(0);
@@ -722,7 +725,19 @@ mod wgpu_integration {
                 run_and_return(event_loop, wgpu_eframe);
             });
         } else {
-            let event_loop = winit::event_loop::EventLoopBuilder::with_user_event().build();
+            let mut event_loop_builder = winit::event_loop::EventLoopBuilder::with_user_event();
+
+            #[cfg(target_os = "android")]
+            {
+                event_loop_builder.with_android_app(
+                    native_options
+                        .android_app
+                        .clone()
+                        .expect("No AndroidApp provided"),
+                );
+            }
+
+            let event_loop = event_loop_builder.build();
             let wgpu_eframe = WgpuWinitApp::new(&event_loop, app_name, native_options, app_creator);
             run_and_exit(event_loop, wgpu_eframe);
         }


### PR DESCRIPTION
This makes things go a bit further on the Android emulator. After it gets stuck on:
```
08-21 08:04:38.612   367   381 E BufferQueueProducer: [SurfaceView - co.realfit.agdkeframe/co.realfit.agdkeframe.MainActivity#0](id:16f0000001e,api:1,p:5829,c:367) connect: already connected (cur=1 req=1)
08-21 08:04:38.613  5829  5856 E libEGL  : eglCreateWindowSurface: native_window_api_connect (win=0xe2b89738) failed (0xffffffea) (already connected to another API?)
08-21 08:04:38.613  5829  5856 E libEGL  : eglCreateWindowSurfaceTmpl:725 error 3003 (EGL_BAD_ALLOC)
08-21 08:04:38.614  5829  5857 I RustStdoutStderr: thread '<unnamed>' panicked at 'Error in Surface::configure: invalid surface', C:\Users\John\.cargo\registry\src\github.com-1ecc6299db9ec823\wgpu-0.13.1\src\backend\direct.rs:281:9
```